### PR TITLE
Fixed #1517

### DIFF
--- a/packages/browser-sync/lib/server/utils.js
+++ b/packages/browser-sync/lib/server/utils.js
@@ -114,6 +114,9 @@ var serverUtils = {
              * the error message good enough.
              */
             var maybe = require.resolve(httpModule);
+            if (httpModule.createSecureServer) {
+                return httpModule.createSecureServer(opts.toJS(), app);
+            }
             return require(maybe);
         }
 


### PR DESCRIPTION
Fixed #1517.

```typescript
http2.createServer = http2.createSecureServer;
```

This hacking method causes problems when using it from TypeScript.
Therefore, it uses native http2 createSecureServer in lib.
